### PR TITLE
Fix invalid Python dictionary syntax

### DIFF
--- a/flashli/configurations.py
+++ b/flashli/configurations.py
@@ -254,7 +254,7 @@ CONFIGURATIONS = types.MappingProxyType({
         ],
         'command': vpxxxx_flash_command,
         'upgrade': vpxxxx_upgrade,
-    }
+    },
      'vp4650': {
         'cpu': '10210U',
         'bios': [


### PR DESCRIPTION
Update configurations.py to fix invalid dictionary syntax for a recently added item. Fixes issue #22.