### PR TITLE
Added interface name on VP4670

### DIFF
--- a/flashli/hardware.py
+++ b/flashli/hardware.py
@@ -257,6 +257,7 @@ def get_mac(debugmode: str) -> str:
     address_dir = ['/sys/class/net/enp1s0f0/address',
                    '/sys/class/net/enp2s0f0/address',
                    '/sys/class/net/eno1/address',
+                   '/sys/class/net/nic0/address',
                    '/sys/class/net/enp1s0/address',
                    '/sys/class/net/enp2s0/address',
                    '/sys/class/net/enp4s0/address',


### PR DESCRIPTION
Running Proxmox (Debian 13-based) on a VP4670, `nicX` are the interfaces name.

If this is not set, I get the `Issue obtaining MAC address`.

Setting this allowed me to successfully update the Coreboot BIOS to the latest version.